### PR TITLE
Added /search/

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,9 @@ This is unofficial API of thepiratebay.org. It is currently hosted on Heroku and
 Recent torrents has option for page number also. Page numbers are 0 indexed.
 Use [https://tpbc.herokuapp.com/recent/page_number/](https://tpbc.herokuapp.com/recent/0/) to access the data.
 
+### Search
+
+Search can be achieved through the `/search/` endpoint. If no term is given, defaults to `/recent/`.
+
 
 **Contributions are welcome**

--- a/app.py
+++ b/app.py
@@ -30,12 +30,19 @@ def recent_torrents(page=0):
     return jsonify(parse_page(url)), 200
 
 @APP.route('/search/<term>', methods=['GET'])
+@APP.route('/search/', methods=['GET'])
+
 def search_torrents(term=None):
   '''
-  Searches TPB using the given term.
+  Searches TPB using the given term. If no term is given, defaults to recent.
   '''
+  url = None
 
-  url = BASE_URL + '/search/' + str(term)
+  if term:
+    url = BASE_URL + '/search/' + str(term)
+  else:
+    url = BASE_URL + '/recent/0'
+  
   return jsonify(parse_page(url)), 200
 
 def parse_page(url):

--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ from flask import Flask, jsonify, render_template
 APP = Flask(__name__)
 EMPTY_LIST = []
 
+BASE_URL = 'https://thepiratebay.org'
+
 
 @APP.route('/', methods=['GET'])
 def index():
@@ -24,9 +26,17 @@ def recent_torrents(page=0):
     '''
     This function implements recent page of TPB
     '''
-    url = 'https://thepiratebay.org/recent/' + str(page)
+    url = BASE_URL + '/recent/' + str(page)
     return jsonify(parse_page(url)), 200
 
+@APP.route('/search/<term>', methods=['GET'])
+def search_torrents(term=None):
+  '''
+  Searches TPB using the given term.
+  '''
+
+  url = BASE_URL + '/search/' + str(term)
+  return jsonify(parse_page(url)), 200
 
 def parse_page(url):
     '''


### PR DESCRIPTION
Added the `/search/` endpoints which mimics the functionality of the TPB site. If no search term is given, the information given defaults to the `/recent/` results.

The README was updated accordingly.

Tested locally.