### PR TITLE
Add List torrents by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is unofficial API of thepiratebay.org. It is currently hosted on Heroku and
 
 ### Sort filters
 
-On `top` and `search` queries, results can be sorted by using the `sort` GET parameter.
+On `top`, `search` and `user` queries, results can be sorted by using the `sort` GET parameter.
 
 Example: `http://<api-address>/top/?sort=title_asc`
 
@@ -34,6 +34,10 @@ Recent torrents can be accessed through the `/recent/page_number/` endpoint.
 ### Search
 
 Search can be accessed through the `/search/search_term/page_number/` endpoint.
+
+### Torrents by User
+
+Get torrents uploaded by a specific user through the `/user/user_name/page_number/` endpoint.
 
 ### Top torrents
 

--- a/app.py
+++ b/app.py
@@ -126,6 +126,23 @@ def search_torrents(term=None, page=0):
     url = BASE_URL + 'search/' + str(term) + '/' + str(page) + '/' + str(sort_arg)
     return jsonify(parse_page(url)), 200
 
+@APP.route('/user/', methods=['GET'])
+def default_list_user():
+    '''
+    Default page for list by user
+    '''
+    return 'No user entered<br/>Format: /user/user_name/page_no(optional)/'
+
+@APP.route('/user/<user>/', methods=['GET'])
+@APP.route('/user/<user>/<int:page>/', methods=['GET'])
+def list_user(user=None, page=0):
+    '''
+    Lists torrents uploaded by user
+    '''
+    sort = request.args.get('sort')
+    sort_arg = sort_filters[request.args.get('sort')] if sort in sort_filters else '7'
+    url = BASE_URL + 'user/' + str(user) + '/' + str(page) + '/' + str(sort_arg)
+    return jsonify(parse_page(url)), 200
 
 def parse_page(url, sort=None):
     '''

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,9 @@
         <a href="/search/">Search torrents</a> 
     </li>
     <li>
+        <a href="/user/">List by user</a>
+    </li>
+    <li>
         <a href="/top/">Top torrents</a> 
     </li>
     <li>


### PR DESCRIPTION
Added a new endpoint to list torrents by a single user. 
Pretty similar to the search endpoint, except tpb seems to require a sort filter. I've defaulted it to seeds_desc so the sort is still optional.